### PR TITLE
Bump ixmp dependency to 3.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - python >=3.6
     # Install requirements
     - click
-    - ixmp >=3.3.0
+    - ixmp >=3.4.0
     - numpy
     - pandas
     # Extra requirements


### PR DESCRIPTION
This PR bumps the ixmp dependency to 3.4.0.

Checklist
* [x] Used a fork of the feedstock to propose changes
* ~[ ] Bumped the build number (if the version is unchanged)~
* ~[ ] Reset the build number to `0` (if the version changed)~
* ~[ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`~
* ~[ ] Ensured the license file is being packaged.~

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
